### PR TITLE
UIREQMED-23 Use caret for react peerDep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update github actions. Refs UIREQMED-14.
 * Add landing page actions: Confirm item arrival, Mediated requests activities and Send item in transit. Refs UIREQMED-2.
 * Hide permission that should not be visible. Refs UIREQMED-20.
+* Add caret to `react` peer dependency. Refs UIREQMED-23.
 
 ## 1.0.0
 * New app created with stripes-cli. Updated module after created with stripes-cli. Refs UIREQMED-1.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-intl": "^6.4.4",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
## Purpose
As package managers become more strict about peerDep specifications all being in agreement with eachother, we want apps to have coordinating versions with their anticipated platform… (`pnpm` complains about a hard dependency on `react@18.2.0` in the app while the platform, stripes, etc, ask for `^18.2.0` or `~18.2.0` - incompatible since the caret or tilde will both pull in a later version.)

The reason this version is specified this way here is because it is from `ui-app-template`  that is automatically copied over when the create command is executed with `stripes-cli`.

[There is a PR on that repo that remedies this.](https://github.com/folio-org/ui-app-template/pull/16) (Merged)

## Refs
[UIREQMED-23](https://folio-org.atlassian.net/browse/UIREQMED-23)
