### PR TITLE
UIREQMED-31: Implement proxy functionality on mediated request form and mediated request details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Implement functionality of `New mediated request` button. Refs UIREQMED-35.
 * Migrate to mediated requests endpoints, refactor constants, utils. Refs UIREQMED-28.
 * Implement Mediated requests details page. Refs UIREQMED-10.
+* Implement proxy functionality on mediated request form and on mediated details page. Refs UIREQMED-31.
 
 ## 1.0.0
 * New app created with stripes-cli. Updated module after created with stripes-cli. Refs UIREQMED-1.

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
         "subPermissions": [
           "circulation.requests.allowed-service-points.get",
           "circulation-storage.request-preferences.collection.get",
+          "proxiesfor.collection.get",
           "requests-mediated.mediated-request.item.post"
         ],
         "visible": false
@@ -121,6 +122,7 @@
         "subPermissions": [
           "circulation.requests.allowed-service-points.get",
           "circulation-storage.request-preferences.collection.get",
+          "proxiesfor.collection.get",
           "requests-mediated.mediated-request.item.put"
         ],
         "visible": false
@@ -131,6 +133,7 @@
         "subPermissions": [
           "circulation.requests.allowed-service-points.get",
           "circulation-storage.request-preferences.collection.get",
+          "proxiesfor.collection.get",
           "requests-mediated.mediated-request.item.put",
           "requests-mediated.mediated-request.item.post"
         ],

--- a/src/components/MediatedRequestsActivities/components/MediatedRequestsDetail/MediatedRequestsDetail.js
+++ b/src/components/MediatedRequestsActivities/components/MediatedRequestsDetail/MediatedRequestsDetail.js
@@ -187,7 +187,7 @@ const MediatedRequestsDetail = ({
                   patronGroup={patronGroup?.group}
                   request={mediatedRequest}
                   userPreferences={userPreferences}
-                  isMediatedRequestDetailPage
+                  proxy={mediatedRequest.proxy}
                 />
               </Accordion>
               <NotesSmartAccordion

--- a/src/components/MediatedRequestsActivities/components/MediatedRequestsDetail/MediatedRequestsDetail.test.js
+++ b/src/components/MediatedRequestsActivities/components/MediatedRequestsDetail/MediatedRequestsDetail.test.js
@@ -78,6 +78,7 @@ describe('MediatedRequestsDetail', () => {
     requestType: MEDIATED_REQUEST_TYPES.HOLD,
     requestLevel: MEDIATED_REQUEST_LEVEL.TITLE,
     patronComments: '',
+    proxy: {},
   };
   const patronGroup = {
     group: 'group',
@@ -188,7 +189,7 @@ describe('MediatedRequestsDetail', () => {
         patronGroup: patronGroup.group,
         request: mediatedRequest,
         userPreferences: {},
-        isMediatedRequestDetailPage: true,
+        proxy: mediatedRequest.proxy,
       };
 
       expect(UserDetail).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});

--- a/src/components/MediatedRequestsActivities/components/RequestForm/RequestForm.js
+++ b/src/components/MediatedRequestsActivities/components/RequestForm/RequestForm.js
@@ -112,6 +112,7 @@ class RequestForm extends React.Component {
     const { titleLevelRequestsFeatureEnabled } = getTlrSettings(settings?.items[0]?.value);
 
     this.state = {
+      proxy: null,
       selectedLoan: loan,
       isItemOrInstanceLoading: false,
       isItemsDialogOpen: false,
@@ -227,6 +228,29 @@ class RequestForm extends React.Component {
       });
   }
 
+  selectProxy = (proxy) => {
+    const {
+      form,
+      selectedUser,
+    } = this.props;
+
+    if (selectedUser.id !== proxy.id) {
+      this.setState({
+        proxy,
+        requestTypes: {},
+        isRequestTypesReceived: false,
+      });
+      form.change(MEDIATED_REQUEST_FORM_FIELD_NAMES.REQUESTER_ID, proxy.id);
+      form.change(MEDIATED_REQUEST_FORM_FIELD_NAMES.PROXY_USER_ID, selectedUser.id);
+      this.findRequestPreferences(proxy.id);
+      this.getAvailableRequestTypes(proxy);
+    }
+  }
+
+  handleCloseProxy = () => {
+    this.setState({ proxy: null });
+  };
+
   findUser = (fieldName, value) => {
     const {
       form,
@@ -238,10 +262,12 @@ class RequestForm extends React.Component {
       isUserLoading: true,
       requestTypes: {},
       isRequestTypesReceived: false,
+      proxy: null,
     });
 
     form.change(MEDIATED_REQUEST_FORM_FIELD_NAMES.PICKUP_SERVICE_POINT_ID, undefined);
     form.change(MEDIATED_REQUEST_FORM_FIELD_NAMES.DELIVERY_ADDRESS_TYPE_ID, undefined);
+    form.change(MEDIATED_REQUEST_FORM_FIELD_NAMES.PROXY_USER_ID, undefined);
 
     return findResource(RESOURCE_TYPES.USER, value, fieldName)
       .then((result) => {
@@ -717,6 +743,7 @@ class RequestForm extends React.Component {
       hasDelivery,
       defaultDeliveryAddressTypeId,
       shouldValidate,
+      proxy,
     } = this.state;
     const {
       handleSubmit,
@@ -862,6 +889,9 @@ class RequestForm extends React.Component {
                       patronGroup={patronGroup}
                       isLoading={isUserLoading}
                       findUser={this.findUser}
+                      selectProxy={this.selectProxy}
+                      handleCloseProxy={this.handleCloseProxy}
+                      proxy={proxy}
                       getUserValidationData={this.getUserValidationData}
                       triggerUserBarcodeValidation={this.triggerUserBarcodeValidation}
                       enterButtonClass={css.enterButton}

--- a/src/components/MediatedRequestsActivities/components/RequesterInformation/RequesterInformation.js
+++ b/src/components/MediatedRequestsActivities/components/RequesterInformation/RequesterInformation.js
@@ -13,7 +13,7 @@ import {
 } from '@folio/stripes/components';
 import { Pluggable } from '@folio/stripes/core';
 
-import UserDetail from '../UserDetail';
+import UserForm from '../UserForm';
 import {
   isFormEditing,
   memoizeValidation,
@@ -47,6 +47,9 @@ class RequesterInformation extends Component {
     isLoading: PropTypes.bool,
     request: PropTypes.object,
     patronGroup: PropTypes.object,
+    proxy: PropTypes.object,
+    selectProxy: PropTypes.func,
+    handleCloseProxy: PropTypes.func,
   };
 
   constructor(props) {
@@ -183,6 +186,9 @@ class RequesterInformation extends Component {
       patronGroup,
       isLoading,
       enterButtonClass,
+      selectProxy,
+      proxy,
+      handleCloseProxy,
     } = this.props;
     const {
       isUserClicked,
@@ -257,10 +263,13 @@ class RequesterInformation extends Component {
             </Col>
           </Row>}
           {(selectedUser?.id || isEditForm) &&
-            <UserDetail
+            <UserForm
               user={user}
               request={request}
               patronGroup={patronGroup?.group}
+              proxy={proxy}
+              selectProxy={selectProxy}
+              handleCloseProxy={handleCloseProxy}
             />
           }
           {

--- a/src/components/MediatedRequestsActivities/components/RequesterInformation/RequesterInformation.test.js
+++ b/src/components/MediatedRequestsActivities/components/RequesterInformation/RequesterInformation.test.js
@@ -18,7 +18,7 @@ import RequesterInformation, {
   COLUMN_MAPPING,
   VISIBLE_COLUMNS,
 } from './RequesterInformation';
-import UserDetail from '../UserDetail';
+import UserForm from '../UserForm';
 import { isFormEditing } from '../../../../utils';
 import {
   MEDIATED_REQUEST_FORM_FIELD_NAMES,
@@ -32,7 +32,7 @@ jest.mock('../../../../utils', () => ({
   isFormEditing: jest.fn(() => false),
   memoizeValidation: (fn) => () => fn,
 }));
-jest.mock('../UserDetail', () => jest.fn(() => <div />));
+jest.mock('../UserForm', () => jest.fn(() => <div />));
 
 const basicProps = {
   triggerUserBarcodeValidation: jest.fn(),
@@ -59,6 +59,9 @@ const basicProps = {
   },
   isLoading: false,
   submitting: false,
+  proxy: {},
+  selectProxy: jest.fn(),
+  handleCloseProxy: jest.fn(),
 };
 const labelIds = {
   selectUser: 'ui-requests-mediated.form.errors.selectUser',
@@ -190,11 +193,14 @@ describe('RequesterInformation', () => {
       isFormEditing.mockReturnValueOnce(true);
     });
 
-    it('should trigger UserDetail with correct props', () => {
+    it('should trigger UserForm with correct props', () => {
       const expectedProps = {
         user: basicProps.request.requester,
         request: basicProps.request,
         patronGroup: basicProps.patronGroup.group,
+        proxy: basicProps.proxy,
+        selectProxy: basicProps.selectProxy,
+        handleCloseProxy: basicProps.handleCloseProxy,
       };
 
       render(
@@ -203,10 +209,10 @@ describe('RequesterInformation', () => {
         />
       );
 
-      expect(UserDetail).toHaveBeenCalledWith(expectedProps, {});
+      expect(UserForm).toHaveBeenCalledWith(expectedProps, {});
     });
 
-    it('should trigger UserDetail with selected user', () => {
+    it('should trigger UserForm with selected user', () => {
       const props = {
         ...basicProps,
         request: undefined,
@@ -224,7 +230,7 @@ describe('RequesterInformation', () => {
         />
       );
 
-      expect(UserDetail).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
+      expect(UserForm).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
     });
   });
 

--- a/src/components/MediatedRequestsActivities/components/UserDetail/UserDetail.js
+++ b/src/components/MediatedRequestsActivities/components/UserDetail/UserDetail.js
@@ -7,23 +7,35 @@ import {
   Row,
 } from '@folio/stripes/components';
 
-import { getRequesterName } from '../../../../utils';
+import {
+  getRequesterName,
+  getProxyInformation,
+} from '../../../../utils';
 import UserHighlightBox from '../UserHighlightBox';
 
 const UserDetail = ({
   user,
   request,
   userPreferences,
+  proxy,
   patronGroup = '',
-  isMediatedRequestDetailPage = false,
 }) => {
   const id = user?.id ?? request.requesterId;
   const name = getRequesterName(user);
+  const proxyInformation = getProxyInformation(proxy, request.proxyUserId);
+  const proxySection = proxyInformation.id ?
+    <UserHighlightBox
+      title={<FormattedMessage id="ui-requests-mediated.requesterDetails.proxy" />}
+      name={proxyInformation.name}
+      id={proxyInformation.id}
+      barcode={proxyInformation.barcode}
+    /> :
+    null;
 
   return (
     <div>
       <UserHighlightBox
-        title={<FormattedMessage id="ui-requests-mediated.requesterDetails.title" />}
+        title={<FormattedMessage id="ui-requests-mediated.requesterDetails.requester" />}
         name={name}
         id={id}
         barcode={user.barcode}
@@ -35,24 +47,20 @@ const UserDetail = ({
             value={patronGroup}
           />
         </Col>
-        {
-          isMediatedRequestDetailPage &&
-            <>
-              <Col xs={4}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests-mediated.requesterDetails.fulfillmentPreference" />}
-                  value={request.fulfillmentPreference}
-                />
-              </Col>
-              <Col xs={4}>
-                <KeyValue
-                  label={userPreferences.label}
-                  value={userPreferences.value}
-                />
-              </Col>
-            </>
-        }
+        <Col xs={4}>
+          <KeyValue
+            label={<FormattedMessage id="ui-requests-mediated.requesterDetails.fulfillmentPreference" />}
+            value={request.fulfillmentPreference}
+          />
+        </Col>
+        <Col xs={4}>
+          <KeyValue
+            label={userPreferences.label}
+            value={userPreferences.value}
+          />
+        </Col>
       </Row>
+      {proxySection}
     </div>
   );
 };
@@ -62,7 +70,7 @@ UserDetail.propTypes = {
   user: PropTypes.object.isRequired,
   request: PropTypes.object,
   userPreferences: PropTypes.object,
-  isMediatedRequestDetailPage: PropTypes.bool,
+  proxy: PropTypes.object,
 };
 
 export default UserDetail;

--- a/src/components/MediatedRequestsActivities/components/UserDetail/UserDetail.test.js
+++ b/src/components/MediatedRequestsActivities/components/UserDetail/UserDetail.test.js
@@ -5,6 +5,7 @@ import {
 
 import UserDetail from './UserDetail';
 import UserHighlightBox from '../UserHighlightBox';
+import { getProxyInformation } from '../../../../utils';
 
 const basicProps = {
   user: {
@@ -13,14 +14,27 @@ const basicProps = {
     id: 'userId',
   },
   patronGroup: 'patronGroup',
+  userPreferences: {
+    label: 'userPreferencesLabel',
+    value: 'userPreferencesValue',
+  },
+  request: {},
+  proxy: {},
 };
 const labelIds = {
-  userTitle: 'ui-requests-mediated.requesterDetails.title',
+  userTitle: 'ui-requests-mediated.requesterDetails.requester',
+  proxyTitle: 'ui-requests-mediated.requesterDetails.proxy',
   patronGroup: 'ui-requests-mediated.requesterDetails.patronGroup',
+};
+const proxy = {
+  name: 'proxyName',
+  id: 'proxyId',
+  barcode: 'proxyBarcode',
 };
 
 jest.mock('../../../../utils', () => ({
   getRequesterName: jest.fn((user) => user.lastName),
+  getProxyInformation: jest.fn(() => proxy),
 }));
 jest.mock('../UserHighlightBox', () => jest.fn(({
   title,
@@ -60,7 +74,7 @@ describe('UserDetail', () => {
       expect(patronGroupTitle).toBeInTheDocument();
     });
 
-    it('should trigger UserHighlightBox with user id', () => {
+    it('should trigger UserHighlightBox with user data', () => {
       const expectedProps = {
         name: basicProps.user.lastName,
         id: basicProps.user.id,
@@ -99,6 +113,50 @@ describe('UserDetail', () => {
       };
 
       expect(UserHighlightBox).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
+    });
+  });
+
+  describe('When proxy information exists', () => {
+    beforeEach(() => {
+      render(
+        <UserDetail
+          {...basicProps}
+        />
+      );
+    });
+
+    it('should render proxy title', () => {
+      const proxyTitle = screen.getByText(labelIds.proxyTitle);
+
+      expect(proxyTitle).toBeInTheDocument();
+    });
+
+    it('should trigger UserHighlightBox with proxy data', () => {
+      const expectedProps = {
+        name: proxy.name,
+        id: proxy.id,
+        barcode: proxy.barcode,
+      };
+
+      expect(UserHighlightBox).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
+    });
+  });
+
+  describe('When proxy information does not exist', () => {
+    beforeEach(() => {
+      getProxyInformation.mockReturnValueOnce({});
+
+      render(
+        <UserDetail
+          {...basicProps}
+        />
+      );
+    });
+
+    it('should not render proxy title', () => {
+      const proxyTitle = screen.queryByText(labelIds.proxyTitle);
+
+      expect(proxyTitle).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/MediatedRequestsActivities/components/UserForm/UserForm.js
+++ b/src/components/MediatedRequestsActivities/components/UserForm/UserForm.js
@@ -1,0 +1,91 @@
+import PropTypes from 'prop-types';
+import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import { useStripes } from '@folio/stripes/core';
+import { ProxyManager } from '@folio/stripes/smart-components';
+import {
+  Col,
+  KeyValue,
+  Row,
+} from '@folio/stripes/components';
+
+import UserHighlightBox from '../UserHighlightBox';
+import {
+  getProxyInformation,
+  getRequesterName,
+} from '../../../../utils';
+
+const UserForm = ({
+  user,
+  request,
+  proxy,
+  selectProxy,
+  handleCloseProxy,
+  patronGroup = '',
+}) => {
+  const stripes = useStripes();
+  const id = user?.id ?? request.requesterId;
+  const name = getRequesterName(user);
+  const ConnectedProxyManager = useMemo(() => stripes.connect(ProxyManager), [stripes]);
+  const proxyInformation = getProxyInformation(proxy, request?.proxyUserId);
+  const userSection = proxyInformation.id ?
+    <UserHighlightBox
+      title={<FormattedMessage id="ui-requests-mediated.requesterDetails.requester" />}
+      name={proxyInformation.name}
+      id={proxyInformation.id}
+      barcode={proxyInformation.barcode}
+    /> :
+    <UserHighlightBox
+      title={<FormattedMessage id="ui-requests-mediated.requesterDetails.requester" />}
+      name={name}
+      id={id}
+      barcode={user.barcode}
+    />;
+  const proxySection = proxyInformation.id ?
+    <UserHighlightBox
+      title={<FormattedMessage id="ui-requests-mediated.requesterDetails.proxy" />}
+      name={name}
+      id={id}
+      barcode={user.barcode}
+    /> :
+    null;
+
+  return (
+    <div>
+      {userSection}
+      <Row>
+        <Col xs={4}>
+          <KeyValue
+            label={<FormattedMessage id="ui-requests-mediated.requesterDetails.patronGroup" />}
+            value={patronGroup}
+          />
+        </Col>
+      </Row>
+      {proxySection}
+      <ConnectedProxyManager
+        patron={user}
+        proxy={proxy}
+        onSelectPatron={selectProxy}
+        onClose={handleCloseProxy}
+      />
+    </div>
+  );
+};
+
+UserForm.propTypes = {
+  user: PropTypes.shape({
+    id: PropTypes.string,
+    barcode: PropTypes.string,
+  }),
+  request: PropTypes.shape({
+    requesterId: PropTypes.string,
+    proxyUserId: PropTypes.string,
+  }),
+  proxy: PropTypes.object,
+  patronGroup: PropTypes.string,
+  selectProxy: PropTypes.func.isRequired,
+  handleCloseProxy: PropTypes.func.isRequired,
+};
+
+export default UserForm;

--- a/src/components/MediatedRequestsActivities/components/UserForm/UserForm.test.js
+++ b/src/components/MediatedRequestsActivities/components/UserForm/UserForm.test.js
@@ -1,0 +1,110 @@
+import {
+  render,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import UserForm from './UserForm';
+import UserHighlightBox from '../UserHighlightBox';
+import { getProxyInformation } from '../../../../utils';
+
+const basicProps = {
+  user: {
+    lastName: 'userLastName',
+    barcode: 'userBarcode',
+    id: 'userId',
+  },
+  request: {},
+  proxy: {},
+  selectProxy: jest.fn(),
+  handleCloseProxy: jest.fn(),
+};
+const labelIds = {
+  userTitle: 'ui-requests-mediated.requesterDetails.requester',
+  proxyTitle: 'ui-requests-mediated.requesterDetails.proxy',
+  patronGroup: 'ui-requests-mediated.requesterDetails.patronGroup',
+};
+const proxy = {
+  name: 'proxyName',
+  id: 'proxyId',
+  barcode: 'proxyBarcode',
+};
+
+jest.mock('../../../../utils', () => ({
+  getProxyInformation: jest.fn(() => proxy),
+  getRequesterName: jest.fn((user) => user.lastName),
+}));
+jest.mock('../UserHighlightBox', () => jest.fn(({
+  title,
+  name,
+  barcode,
+}) => (
+  <>
+    <span>{title}</span>
+    <span>{name}</span>
+    <span>{barcode}</span>
+  </>
+)));
+
+describe('UserForm', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('When proxy information is provided', () => {
+    beforeEach(() => {
+      render(
+        <UserForm
+          {...basicProps}
+        />
+      );
+    });
+
+    it('should render patron group title', () => {
+      const patronGroupTitle = screen.getByText(labelIds.patronGroup);
+
+      expect(patronGroupTitle).toBeInTheDocument();
+    });
+
+    it('should render user title', () => {
+      const userTitle = screen.getByText(labelIds.userTitle);
+
+      expect(userTitle).toBeInTheDocument();
+    });
+
+    it('should trigger UserHighlightBox with user data', () => {
+      const expectedProps = {
+        id: basicProps.user.id,
+        barcode: basicProps.user.barcode,
+        name: basicProps.user.lastName,
+      };
+
+      expect(UserHighlightBox).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
+    });
+
+    it('should trigger UserHighlightBox with proxy data', () => {
+      const expectedProps = {
+        id: proxy.id,
+        name: proxy.name,
+        barcode: proxy.barcode,
+      };
+
+      expect(UserHighlightBox).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
+    });
+  });
+
+  describe('When proxy information is not provided', () => {
+    beforeEach(() => {
+      getProxyInformation.mockReturnValueOnce({});
+
+      render(
+        <UserForm
+          {...basicProps}
+        />
+      );
+    });
+
+    it('should trigger UserHighlightBox once', () => {
+      expect(UserHighlightBox).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/MediatedRequestsActivities/components/UserForm/index.js
+++ b/src/components/MediatedRequestsActivities/components/UserForm/index.js
@@ -1,0 +1,1 @@
+export { default } from './UserForm';

--- a/src/constants/mediatedRequestsActivities.js
+++ b/src/constants/mediatedRequestsActivities.js
@@ -153,6 +153,7 @@ export const MEDIATED_REQUEST_FORM_FIELD_NAMES = {
   REQUESTER: 'requester',
   REQUESTER_ID: 'requesterId',
   REQUESTER_BARCODE: 'requester.barcode',
+  PROXY_USER_ID: 'proxyUserId',
   ITEM_ID: 'itemId',
   ITEM_BARCODE: 'item.barcode',
   INSTANCE_ID: 'instanceId',

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,8 @@ import {
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 
+import { NoValue } from '@folio/stripes/components';
+
 import AddressDetails from './components/MediatedRequestsActivities/components/AddressDetails';
 import {
   DEFAULT_VIEW_VALUE,
@@ -297,4 +299,16 @@ export const formatNoteReferrerEntityData = (entityData) => {
 
 export const getUserHighlightBoxLink = (linkText, id) => {
   return linkText ? <Link to={`/users/view/${id}`}>{linkText}</Link> : <></>;
+};
+
+export const getProxyInformation = (proxy, proxyIdFromRequest) => {
+  if (proxy) {
+    return {
+      name: getRequesterName(proxy),
+      barcode: proxy.barcode || <NoValue />,
+      id: proxy.id || proxyIdFromRequest,
+    };
+  }
+
+  return {};
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -3,6 +3,8 @@ import {
   screen,
 } from '@folio/jest-config-stripes/testing-library/react';
 
+import { NoValue } from '@folio/stripes/components';
+
 import {
   transformRequestFilterOptions,
   getIsTitleLevelRequestsFeatureEnabled,
@@ -31,6 +33,7 @@ import {
   getReferredRecordData,
   formatNoteReferrerEntityData,
   getUserHighlightBoxLink,
+  getProxyInformation,
 } from './utils';
 import {
   FULFILMENT_TYPES,
@@ -807,6 +810,60 @@ describe('utils', () => {
       render(getUserHighlightBoxLink(linkText));
 
       expect(screen.getByText(linkText)).toBeInTheDocument();
+    });
+  });
+
+  describe('getProxyInformation', () => {
+    describe('When proxy is provided', () => {
+      it('should return proxy information with barcode', () => {
+        const proxy = {
+          id: 'id',
+          lastName: 'lastName',
+          barcode: 'barcode',
+        };
+        const expectedResult = {
+          name: proxy.lastName,
+          id: proxy.id,
+          barcode: proxy.barcode,
+        };
+
+        expect(getProxyInformation(proxy)).toEqual(expectedResult);
+      });
+
+      it('should return proxy information without barcode', () => {
+        const proxy = {
+          id: 'id',
+          lastName: 'lastName',
+        };
+        const expectedResult = {
+          name: proxy.lastName,
+          id: proxy.id,
+          barcode: <NoValue />,
+        };
+
+        expect(getProxyInformation(proxy)).toEqual(expectedResult);
+      });
+
+      it('should return proxy information with proxyIdFromRequest', () => {
+        const proxyIdFromRequest = 'proxyIdFromRequest';
+        const proxy = {
+          lastName: 'lastName',
+          barcode: 'barcode',
+        };
+        const expectedResult = {
+          name: proxy.lastName,
+          id: proxyIdFromRequest,
+          barcode: proxy.barcode,
+        };
+
+        expect(getProxyInformation(proxy, proxyIdFromRequest)).toEqual(expectedResult);
+      });
+    });
+
+    describe('When proxy is not provided', () => {
+      it('should return empty object', () => {
+        expect(getProxyInformation()).toEqual({});
+      });
     });
   });
 });

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -38,4 +38,7 @@ jest.mock('@folio/stripes/core', () => ({
       </>
     );
   }),
+  useStripes: jest.fn(() => ({
+    connect: Component => Component,
+  })),
 }));

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -42,6 +42,7 @@ jest.mock('@folio/stripes/smart-components', () => ({
       </button>
     </div>
   )),
+  ProxyManager: jest.fn(() => <div />),
   SearchAndSortNoResultsMessage: jest.fn((props) => (<div {...props} />)),
   ViewMetaData: jest.fn(({ metadata, ...rest }) => (
     <div {...rest}>{metadata.createdDate}</div>

--- a/translations/ui-requests-mediated/en.json
+++ b/translations/ui-requests-mediated/en.json
@@ -130,7 +130,8 @@
   "instanceDetails.edition": "Edition",
   "instanceDetails.identifiers": "ISBN(s)",
 
-  "requesterDetails.title": "Requester",
+  "requesterDetails.requester": "Requester",
+  "requesterDetails.proxy": "Requester's proxy",
   "requesterDetails.patronGroup": "Requester patron group",
   "requesterDetails.barcode": "Barcode",
   "requesterDetails.deliveryAddress": "Delivery address",


### PR DESCRIPTION
## Purpose
Implement proxy functionality on mediated request form and mediated request details page

## Refs
[UIREQMED-31](https://folio-org.atlassian.net/browse/UIREQMED-31)

## Screenshots
![image](https://github.com/user-attachments/assets/eeb7110e-c995-4981-b5a2-19c7e1d51c4e)


![image](https://github.com/user-attachments/assets/0da6629c-b9d1-4dbc-8fa4-90d5c66e7815)



![image](https://github.com/user-attachments/assets/9f409b93-36b5-4b4c-8ba1-9c789f8c9a88)
