### PR TITLE
UIREQMED-44: Persist filters when changing between actions

### DIFF
--- a/src/components/NavigationMenu/NavigationMenu.js
+++ b/src/components/NavigationMenu/NavigationMenu.js
@@ -57,7 +57,7 @@ export const handleChangeMenu = (event, location, history) => {
   if (pathname === getMediatedRequestsActivitiesUrl()) {
     destination.search = location.state;
   } else {
-    destination.state = location.search;
+    destination.state = location.search ? location.search : destination.state;
   }
 
   history.push(destination);

--- a/src/components/NavigationMenu/NavigationMenu.test.js
+++ b/src/components/NavigationMenu/NavigationMenu.test.js
@@ -133,7 +133,7 @@ describe('NavigationMenu', () => {
       }));
     });
 
-    it('should handle correct when pathname not equal mediated requests activities', () => {
+    it('should handle correct when pathname not equal mediated requests activities with empty search', () => {
       const event = {
         target: {
           value: getConfirmItemArrivalUrl(),
@@ -143,6 +143,29 @@ describe('NavigationMenu', () => {
         pathname: getMediatedRequestsActivitiesUrl(),
         state: '',
         search: '',
+      };
+      const history = {
+        location,
+        push,
+      };
+
+      handleChangeMenu(event, location, history);
+
+      expect(push).toHaveBeenCalledWith(expect.objectContaining({
+        pathname: getConfirmItemArrivalUrl(),
+      }));
+    });
+
+    it('should handle correct when pathname not equal mediated requests activities with not empty search', () => {
+      const event = {
+        target: {
+          value: getConfirmItemArrivalUrl(),
+        },
+      };
+      const location = {
+        pathname: getMediatedRequestsActivitiesUrl(),
+        state: '',
+        search: '?query=Test',
       };
       const history = {
         location,


### PR DESCRIPTION
## Purpose
Persist filters when changing between actions

## Approach 
Pull request associated with https://github.com/folio-org/ui-requests-mediated/pull/66
We should not update `destination.state` when we have empty `location.search`. This can happen on switch between `activities`.

## Refs
https://issues.folio.org/browse/UIREQMED-44