### PR TITLE
UIREQMED-75: Search result are not showing any result after user clear search field in Mediated requests app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Make "Enter" buttons shorter using default styles. Refs UIREQMED-71.
 * Cover src/index.js file by jest/RTL tests. Refs UIREQMED-68.
 * Increase code coverage of RequestForm.js file by jest/RTL tests. Refs UIREQMED-69.
+* Fix issue with search field when user clears search value. Refs UIREQMED-75.
 
 ## [2.0.1] (https://github.com/folio-org/ui-requests-mediated/tree/v2.0.1) (2024-12-06)
 [Full Changelog](https://github.com/folio-org/ui-requests-mediated/compare/v2.0.0...v2.0.1)

--- a/src/routes/MediatedRequestsActivitiesContainer.js
+++ b/src/routes/MediatedRequestsActivitiesContainer.js
@@ -137,6 +137,7 @@ class MediatedRequestsActivitiesContainer extends React.Component {
         resultOffset,
       },
     } = this.props;
+    const isAnyFilterSelected = Object.keys(state.filterFields).some(filterName => state.filterFields[filterName]?.length);
 
     if (nsValues.query) {
       nsValues.query = nsValues.query.replace('*', '');
@@ -146,7 +147,7 @@ class MediatedRequestsActivitiesContainer extends React.Component {
       resultOffset.replace(0);
     }
 
-    if (/reset/.test(state.changeType)) {
+    if (/reset/.test(state.changeType) && !isAnyFilterSelected) {
       query.replace(nsValues);
     } else {
       query.update(nsValues);

--- a/src/routes/MediatedRequestsActivitiesContainer.test.js
+++ b/src/routes/MediatedRequestsActivitiesContainer.test.js
@@ -13,6 +13,7 @@ import MediatedRequestsActivities from '../components/MediatedRequestsActivities
 import {
   PAGE_AMOUNT,
   MEDIATED_REQUESTS_RECORDS_NAME,
+  MEDIATED_REQUEST_STATUS,
 } from '../constants';
 
 const testIds = {
@@ -141,6 +142,7 @@ describe('MediatedRequestsActivitiesContainer', () => {
         state: {
           sortChanged: true,
           changeType: 'reset',
+          filterFields: {},
         },
       };
 
@@ -173,6 +175,9 @@ describe('MediatedRequestsActivitiesContainer', () => {
         state: {
           sortChanged: false,
           changeType: '',
+          filterFields: {
+            status: [MEDIATED_REQUEST_STATUS.NEW_AWAITING_CONFIRMATION],
+          },
         },
       };
 


### PR DESCRIPTION
## Purpose
Fix issue with search field when user selected some filter(s), added search value, received result and cleared search value. In this case search result should contain information that relies on selected filter(s).

## Refs
[UIREQMED-75](https://folio-org.atlassian.net/browse/UIREQMED-75)