### PR TITLE
UIREQMED-84: Fix issue with error callout while confirming request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix issue with search field when user clears search value. Refs UIREQMED-75.
 * Fix accessibility issues. Refs UIREQMED-74.
 * Fix accessibility issues related to mediated requests list. Refs UIREQMED-76.
+* Fix issue with error callout while confirming request. Refs UIREQMED-84.
 
 ## [2.0.1] (https://github.com/folio-org/ui-requests-mediated/tree/v2.0.1) (2024-12-06)
 [Full Changelog](https://github.com/folio-org/ui-requests-mediated/compare/v2.0.0...v2.0.1)

--- a/src/components/MediatedRequestsActivities/components/RequestFormContainer/RequestFormContainer.js
+++ b/src/components/MediatedRequestsActivities/components/RequestFormContainer/RequestFormContainer.js
@@ -158,7 +158,7 @@ const RequestFormContainer = ({
     if (selectedProxy) {
       userData = selectedProxy;
     } else {
-      userData = requestData.requester;
+      userData = selectedUser;
     }
 
     if (!requestData.requestType) {


### PR DESCRIPTION
## Purpose
 When user tries to confirm a previously created mediated request he sees error callout even if we have successful response from the server. Instead of that user should see success callout with appropriate message.

## Approach
The issue happened because we used incorrect data object to get user information. Currently we will use correct object with user data.

## Refs
[UIREQMED-84](https://folio-org.atlassian.net/browse/UIREQMED-84)