### PR TITLE
UIREQMED-85: Update upload-artifact actions from v3 to v4

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -147,7 +147,7 @@ jobs:
           data: ${{ steps.moduleDescriptor.outputs.content }}
 
       - name: Upload event file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload Jest results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jest-test-results
           path: ${{ env.JEST_JUNIT_OUTPUT_DIR }}/*.xml

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -87,7 +87,7 @@ jobs:
         run: cat module-descriptor.json
 
       - name: Upload event file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload Jest results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jest-test-results
           path: ${{ env.JEST_JUNIT_OUTPUT_DIR }}/*.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix issue with search field when user clears search value. Refs UIREQMED-75.
 * Fix accessibility issues. Refs UIREQMED-74.
 * Fix accessibility issues related to mediated requests list. Refs UIREQMED-76.
+* Update upload-artifact actions from v3 to v4 version. Refs UIREQMED-85.
 
 ## [2.0.1] (https://github.com/folio-org/ui-requests-mediated/tree/v2.0.1) (2024-12-06)
 [Full Changelog](https://github.com/folio-org/ui-requests-mediated/compare/v2.0.0...v2.0.1)


### PR DESCRIPTION
## Purpose
Update upload-artifact actions from v3 to v4 to make builds successful.

## Refs
[UIREQMED-85](https://folio-org.atlassian.net/browse/UIREQMED-85)