### PR TITLE
UIREQMED-91: Implement support for fields without information in Mediated requests UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * *BREAKING* Update `react-intl` to `^7`. Refs UIREQMED-89.
 * Migrate to shared GA workflows. Refs UIREQMED-87.
 * *BREAKING* Update stripes-* dependencies to latest version. Refs UIREQMED-88.
+* Use NoValue component for missed data. Refs UIREQMED-91.
 
 ## [2.0.2] (https://github.com/folio-org/ui-requests-mediated/tree/v2.0.2) (2025-02-07)
 [Full Changelog](https://github.com/folio-org/ui-requests-mediated/compare/v2.0.1...v2.0.2)

--- a/src/components/ConfirmItem/components/ConfirmItemList.js
+++ b/src/components/ConfirmItem/components/ConfirmItemList.js
@@ -13,6 +13,7 @@ import {
 import {
   FormattedTime,
   MultiColumnList,
+  NoValue,
 } from '@folio/stripes/components';
 import {
   effectiveCallNumber,
@@ -78,23 +79,23 @@ export const getConfirmItemListFormatter = (confirmItemType) => ({
     );
   },
   [CONFIRM_ITEM_RECORD_FIELD_NAME.TITLE]: (confirmItem) => (
-    get(confirmItem, CONFIRM_ITEM_RECORD_FIELD_PATH[CONFIRM_ITEM_RECORD_FIELD_NAME.TITLE], DEFAULT_VIEW_VALUE)
+    get(confirmItem, CONFIRM_ITEM_RECORD_FIELD_PATH[CONFIRM_ITEM_RECORD_FIELD_NAME.TITLE], <NoValue />)
   ),
   [CONFIRM_ITEM_RECORD_FIELD_NAME.ITEM_BARCODE]: (confirmItem) => (
-    get(confirmItem, CONFIRM_ITEM_RECORD_FIELD_PATH[CONFIRM_ITEM_RECORD_FIELD_NAME.ITEM_BARCODE], DEFAULT_VIEW_VALUE)
+    get(confirmItem, CONFIRM_ITEM_RECORD_FIELD_PATH[CONFIRM_ITEM_RECORD_FIELD_NAME.ITEM_BARCODE], <NoValue />)
   ),
 
   [CONFIRM_ITEM_RECORD_FIELD_NAME.EFFECTIVE_CALL_NUMBER]: (confirmItem) => {
     const item = get(confirmItem, CONFIRM_ITEM_RECORD_FIELD_PATH[CONFIRM_ITEM_RECORD_FIELD_NAME.ITEM], {});
 
-    return effectiveCallNumber(item);
+    return effectiveCallNumber(item) || <NoValue />;
   },
   [CONFIRM_ITEM_RECORD_FIELD_NAME.MEDIATED_REQUEST_STATUS]: (confirmItem) => (
-    get(confirmItem, CONFIRM_ITEM_RECORD_FIELD_PATH[CONFIRM_ITEM_RECORD_FIELD_NAME.MEDIATED_REQUEST_STATUS], DEFAULT_VIEW_VALUE)
+    get(confirmItem, CONFIRM_ITEM_RECORD_FIELD_PATH[CONFIRM_ITEM_RECORD_FIELD_NAME.MEDIATED_REQUEST_STATUS], <NoValue />)
   ),
-  [CONFIRM_ITEM_RECORD_FIELD_NAME.REQUESTER]: (confirmItem) => (getRequesterName(confirmItem)),
+  [CONFIRM_ITEM_RECORD_FIELD_NAME.REQUESTER]: (confirmItem) => (getRequesterName(confirmItem) || <NoValue />),
   [CONFIRM_ITEM_RECORD_FIELD_NAME.REQUESTER_BARCODE]: (confirmItem) => (
-    get(confirmItem, CONFIRM_ITEM_RECORD_FIELD_PATH[CONFIRM_ITEM_RECORD_FIELD_NAME.REQUESTER_BARCODE], DEFAULT_VIEW_VALUE)
+    get(confirmItem, CONFIRM_ITEM_RECORD_FIELD_PATH[CONFIRM_ITEM_RECORD_FIELD_NAME.REQUESTER_BARCODE], <NoValue />)
   ),
 });
 export const getEmptyMessage = (contentData) => (

--- a/src/components/ConfirmItem/components/ConfirmItemList.test.js
+++ b/src/components/ConfirmItem/components/ConfirmItemList.test.js
@@ -13,6 +13,7 @@ import {
 import {
   MultiColumnList,
   FormattedTime,
+  NoValue,
 } from '@folio/stripes/components';
 import {
   effectiveCallNumber,
@@ -29,7 +30,6 @@ import {
   APP_ICON_NAME,
   CONFIRM_ITEM_TYPES,
   CONFIRM_ITEM_RECORD_FIELD_NAME,
-  DEFAULT_VIEW_VALUE,
 } from '../../../constants';
 
 const contentData = [];
@@ -104,7 +104,7 @@ describe('getConfirmItemListFormatter', () => {
     });
 
     it('should return default value for title', () => {
-      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.TITLE]()).toBe(DEFAULT_VIEW_VALUE);
+      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.TITLE]()).toEqual(<NoValue />);
     });
   });
 
@@ -114,7 +114,7 @@ describe('getConfirmItemListFormatter', () => {
     });
 
     it('should return default value for barcode', () => {
-      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.ITEM_BARCODE]()).toBe(DEFAULT_VIEW_VALUE);
+      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.ITEM_BARCODE]()).toEqual(<NoValue />);
     });
   });
 
@@ -143,6 +143,12 @@ describe('getConfirmItemListFormatter', () => {
 
       expect(effectiveCallNumber).toHaveBeenCalledWith(item);
     });
+
+    it('should return default value for effective call number', () => {
+      effectiveCallNumber.mockReturnValueOnce('');
+
+      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.EFFECTIVE_CALL_NUMBER]()).toEqual(<NoValue />);
+    });
   });
 
   describe('status', () => {
@@ -151,7 +157,7 @@ describe('getConfirmItemListFormatter', () => {
     });
 
     it('should return default value for status', () => {
-      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.MEDIATED_REQUEST_STATUS]()).toBe(DEFAULT_VIEW_VALUE);
+      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.MEDIATED_REQUEST_STATUS]()).toEqual(<NoValue />);
     });
   });
 
@@ -161,7 +167,7 @@ describe('getConfirmItemListFormatter', () => {
     });
 
     it('should return default value for requester', () => {
-      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.REQUESTER]()).toBe(DEFAULT_VIEW_VALUE);
+      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.REQUESTER]()).toEqual(<NoValue />);
     });
   });
 
@@ -171,7 +177,7 @@ describe('getConfirmItemListFormatter', () => {
     });
 
     it('should return default value for requester barcode', () => {
-      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.REQUESTER_BARCODE]()).toBe(DEFAULT_VIEW_VALUE);
+      expect(getConfirmItemListFormatter(props.confirmItemType)[CONFIRM_ITEM_RECORD_FIELD_NAME.REQUESTER_BARCODE]()).toEqual(<NoValue />);
     });
   });
 });

--- a/src/components/MediatedRequestsActivities/components/ItemsDialog/ItemsDialog.js
+++ b/src/components/MediatedRequestsActivities/components/ItemsDialog/ItemsDialog.js
@@ -10,6 +10,7 @@ import {
   Paneset,
   Loading,
   Layout,
+  NoValue,
 } from '@folio/stripes/components';
 
 import {
@@ -42,10 +43,11 @@ export const COLUMN_MAP = {
   loanType: <FormattedMessage id="ui-requests-mediated.itemsDialog.loanType" />,
 };
 export const formatter = {
+  barcode: item => item?.barcode || <NoValue />,
   itemStatus: item => <FormattedMessage id={ITEM_STATUS_TRANSLATION_KEYS[item.status.name]} />,
-  location: item => get(item, 'location.name', ''),
+  location: item => get(item, 'location.name', <NoValue />),
   materialType: item => item.materialType.name,
-  loanType: item => (item.temporaryLoanType ? get(item, 'temporaryLoanType.name', '') : get(item, 'permanentLoanType.name', '')),
+  loanType: item => (item.temporaryLoanType ? get(item, 'temporaryLoanType.name', <NoValue />) : get(item, 'permanentLoanType.name', <NoValue />)),
 };
 export const MAX_HEIGHT = 500;
 

--- a/src/components/MediatedRequestsActivities/components/ItemsDialog/ItemsDialog.test.js
+++ b/src/components/MediatedRequestsActivities/components/ItemsDialog/ItemsDialog.test.js
@@ -6,6 +6,7 @@ import {
 import {
   Modal,
   MultiColumnList,
+  NoValue,
 } from '@folio/stripes/components';
 
 import {
@@ -158,6 +159,7 @@ describe('ItemsDialog', () => {
 
   describe('formatter', () => {
     const item = {
+      barcode: 'barcode',
       status: {
         name: ITEM_STATUSES.AGED_TO_LOST,
       },
@@ -172,6 +174,16 @@ describe('ItemsDialog', () => {
       },
     };
 
+    describe('barcode', () => {
+      it('should return item barcode', () => {
+        expect(formatter.barcode(item)).toBe(item.barcode);
+      });
+
+      it('should return default value', () => {
+        expect(formatter.barcode()).toEqual(<NoValue />);
+      });
+    });
+
     describe('itemStatus', () => {
       it('should return formatted message', () => {
         expect(formatter.itemStatus(item).props.id).toBe(ITEM_STATUS_TRANSLATION_KEYS[[ITEM_STATUSES.AGED_TO_LOST]]);
@@ -181,6 +193,10 @@ describe('ItemsDialog', () => {
     describe('location', () => {
       it('should return location name', () => {
         expect(formatter.location(item)).toBe(item.location.name);
+      });
+
+      it('should return default value', () => {
+        expect(formatter.location()).toEqual(<NoValue />);
       });
     });
 
@@ -195,6 +211,14 @@ describe('ItemsDialog', () => {
         it('should return temporary loan type name', () => {
           expect(formatter.loanType(item)).toBe(item.temporaryLoanType.name);
         });
+
+        it('should return default value', () => {
+          const itemWithoutLoanType = {
+            temporaryLoanType: {},
+          };
+
+          expect(formatter.loanType(itemWithoutLoanType)).toEqual(<NoValue />);
+        });
       });
 
       describe('Without temporaryLoanType', () => {
@@ -208,6 +232,14 @@ describe('ItemsDialog', () => {
           };
 
           expect(formatter.loanType(itemWithPermanentLoanType)).toBe(itemWithPermanentLoanType.permanentLoanType.name);
+        });
+
+        it('should return default value', () => {
+          const itemWithoutLoanType = {
+            permanentLoanType: {},
+          };
+
+          expect(formatter.loanType(itemWithoutLoanType)).toEqual(<NoValue />);
         });
       });
     });

--- a/src/components/MediatedRequestsActivities/components/MediatedRequestsList/MediatedRequestsList.js
+++ b/src/components/MediatedRequestsActivities/components/MediatedRequestsList/MediatedRequestsList.js
@@ -15,6 +15,7 @@ import {
   FormattedTime,
   MCLPagingTypes,
   TextLink,
+  NoValue,
 } from '@folio/stripes/components';
 
 import {
@@ -56,15 +57,17 @@ export const COLUMN_WIDTHS = {
   [MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER_BARCODE]: { max: 120 },
 };
 export const getMediatedRequestsListFormatter = (location) => ({
-  [MEDIATED_REQUESTS_RECORD_FIELD_NAME.TITLE]: (mediatedRequest) => (
-    <TextLink
-      to={`/${MODULE_ROUTE}/${MEDIATED_REQUESTS_ACTIVITIES}/preview/${mediatedRequest[MEDIATED_REQUESTS_RECORD_FIELD_NAME.ID]}${location.search}`}
-    >
-      {get(mediatedRequest, MEDIATED_REQUESTS_RECORD_FIELD_PATH[MEDIATED_REQUESTS_RECORD_FIELD_NAME.TITLE], DEFAULT_VIEW_VALUE)}
-    </TextLink>
-  ),
+  [MEDIATED_REQUESTS_RECORD_FIELD_NAME.TITLE]: (mediatedRequest) => {
+    const title = get(mediatedRequest, MEDIATED_REQUESTS_RECORD_FIELD_PATH[MEDIATED_REQUESTS_RECORD_FIELD_NAME.TITLE]);
+
+    return title ?
+      <TextLink to={`/${MODULE_ROUTE}/${MEDIATED_REQUESTS_ACTIVITIES}/preview/${mediatedRequest[MEDIATED_REQUESTS_RECORD_FIELD_NAME.ID]}${location.search}`}>
+        {title}
+      </TextLink> :
+      <NoValue />;
+  },
   [MEDIATED_REQUESTS_RECORD_FIELD_NAME.ITEM_BARCODE]: (mediatedRequest) => (
-    get(mediatedRequest, MEDIATED_REQUESTS_RECORD_FIELD_PATH[MEDIATED_REQUESTS_RECORD_FIELD_NAME.ITEM_BARCODE], DEFAULT_VIEW_VALUE)
+    get(mediatedRequest, MEDIATED_REQUESTS_RECORD_FIELD_PATH[MEDIATED_REQUESTS_RECORD_FIELD_NAME.ITEM_BARCODE], <NoValue />)
   ),
   [MEDIATED_REQUESTS_RECORD_FIELD_NAME.MEDIATED_REQUEST_DATE]: (mediatedRequest) => (
     <AppIcon
@@ -82,14 +85,14 @@ export const getMediatedRequestsListFormatter = (location) => ({
   [MEDIATED_REQUESTS_RECORD_FIELD_NAME.EFFECTIVE_CALL_NUMBER]: (mediatedRequest) => {
     const item = get(mediatedRequest, MEDIATED_REQUESTS_RECORD_FIELD_PATH[MEDIATED_REQUESTS_RECORD_FIELD_NAME.ITEM], {});
 
-    return effectiveCallNumber(item);
+    return effectiveCallNumber(item) || <NoValue />;
   },
   [MEDIATED_REQUESTS_RECORD_FIELD_NAME.STATUS]: (mediatedRequest) => (
-    get(mediatedRequest, MEDIATED_REQUESTS_RECORD_FIELD_PATH[MEDIATED_REQUESTS_RECORD_FIELD_NAME.STATUS], DEFAULT_VIEW_VALUE)
+    get(mediatedRequest, MEDIATED_REQUESTS_RECORD_FIELD_PATH[MEDIATED_REQUESTS_RECORD_FIELD_NAME.STATUS], <NoValue />)
   ),
-  [MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER]: (mediatedRequest) => (getRequesterName(mediatedRequest)),
+  [MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER]: (mediatedRequest) => (getRequesterName(mediatedRequest) || <NoValue />),
   [MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER_BARCODE]: (mediatedRequest) => (
-    get(mediatedRequest, MEDIATED_REQUESTS_RECORD_FIELD_PATH[MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER_BARCODE], DEFAULT_VIEW_VALUE)
+    get(mediatedRequest, MEDIATED_REQUESTS_RECORD_FIELD_PATH[MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER_BARCODE], <NoValue />)
   ),
 });
 export const emptyMessage = (source, query) => (

--- a/src/components/MediatedRequestsActivities/components/MediatedRequestsList/MediatedRequestsList.test.js
+++ b/src/components/MediatedRequestsActivities/components/MediatedRequestsList/MediatedRequestsList.test.js
@@ -13,6 +13,7 @@ import {
 import {
   MultiColumnList,
   FormattedTime,
+  NoValue,
 } from '@folio/stripes/components';
 import {
   SearchAndSortNoResultsMessage,
@@ -33,7 +34,6 @@ import MediatedRequestsList, {
 
 import {
   APP_ICON_NAME,
-  DEFAULT_VIEW_VALUE,
   MEDIATED_REQUESTS_RECORD_FIELD_NAME,
   MEDIATED_REQUESTS_RECORD_TRANSLATIONS,
 } from '../../../../constants';
@@ -147,7 +147,7 @@ describe('getMediatedRequestsListFormatter', () => {
     });
 
     it('should return default value for barcode', () => {
-      expect(formatter[MEDIATED_REQUESTS_RECORD_FIELD_NAME.ITEM_BARCODE]()).toBe(DEFAULT_VIEW_VALUE);
+      expect(formatter[MEDIATED_REQUESTS_RECORD_FIELD_NAME.ITEM_BARCODE]()).toEqual(<NoValue />);
     });
   });
 
@@ -176,6 +176,12 @@ describe('getMediatedRequestsListFormatter', () => {
 
       expect(effectiveCallNumber).toHaveBeenCalledWith(item);
     });
+
+    it('should return default value for effective call number', () => {
+      effectiveCallNumber.mockReturnValueOnce('');
+
+      expect(formatter[MEDIATED_REQUESTS_RECORD_FIELD_NAME.EFFECTIVE_CALL_NUMBER]()).toEqual(<NoValue />);
+    });
   });
 
   describe('status', () => {
@@ -184,7 +190,7 @@ describe('getMediatedRequestsListFormatter', () => {
     });
 
     it('should return default value for status', () => {
-      expect(formatter[MEDIATED_REQUESTS_RECORD_FIELD_NAME.STATUS]()).toBe(DEFAULT_VIEW_VALUE);
+      expect(formatter[MEDIATED_REQUESTS_RECORD_FIELD_NAME.STATUS]()).toEqual(<NoValue />);
     });
   });
 
@@ -194,7 +200,7 @@ describe('getMediatedRequestsListFormatter', () => {
     });
 
     it('should return default value for requester', () => {
-      expect(formatter[MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER]()).toBe(DEFAULT_VIEW_VALUE);
+      expect(formatter[MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER]()).toEqual(<NoValue />);
     });
   });
 
@@ -204,7 +210,7 @@ describe('getMediatedRequestsListFormatter', () => {
     });
 
     it('should return default value for requester barcode', () => {
-      expect(formatter[MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER_BARCODE]()).toBe(DEFAULT_VIEW_VALUE);
+      expect(formatter[MEDIATED_REQUESTS_RECORD_FIELD_NAME.REQUESTER_BARCODE]()).toEqual(<NoValue />);
     });
   });
 });


### PR DESCRIPTION
## Purpose
Use "NoValue" component instead of empty string for missed data.

## Refs
[UIREQMED-91](https://folio-org.atlassian.net/browse/UIREQMED-91)