### PR TITLE
UIREQMED-117: Added global permissions for get read-access to values such as tenant’s locale, timezone, and currency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
         "permissionName": "module.requests-mediated.enabled",
         "displayName": "UI: Mediated requests module is enabled",
         "subPermissions": [
-          "mod-settings.global.read.stripes-core.prefs.manage",
-          "mod-settings.entries.collection.get"
+          "stripes-core.settings.read"
         ]
       },
       {


### PR DESCRIPTION
## Purpose
Added global permissions for get read-access to values such as tenant’s locale, time zone, and currency

This pull request associated with https://github.com/folio-org/ui-requests-mediated/pull/131 after changes in epic we need provide corresponding changes


## Refs
https://folio-org.atlassian.net/browse/UIREQMED-117